### PR TITLE
Add matched value in API output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,19 +42,21 @@ Example
             .build()
             .unwrap();
 
-        let sentence = "My favourite artists are the stones and the fab four";
+        let sentence = "My favourite artists are the stones and the amazing fab four";
         let extracted_entities = parser.run(sentence).unwrap();
         assert_eq!(extracted_entities,
                    vec![
                        ParsedValue {
                            raw_value: "the stones".to_string(),
+                           matched_value: "the rolling stones".to_string(),
                            resolved_value: "The Rolling Stones".to_string(),
                            range: 25..35,
                        },
                        ParsedValue {
-                           raw_value: "the fab four".to_string(),
+                           raw_value: "fab four".to_string(),
+                           matched_value: "the fab four".to_string(),
                            resolved_value: "The Beatles".to_string(),
-                           range: 40..52,
+                           range: 52..60,
                        }]);
     }
 

--- a/examples/entity_parsing_from_scratch.rs
+++ b/examples/entity_parsing_from_scratch.rs
@@ -28,7 +28,7 @@ fn main() {
         .build()
         .unwrap();
 
-    let sentence = "My favourite artists are the stones and the fab four";
+    let sentence = "My favourite artists are the stones and fab four";
     let extracted_entities = parser.run(sentence).unwrap();
     assert_eq!(extracted_entities,
                vec![
@@ -36,10 +36,12 @@ fn main() {
                        raw_value: "the stones".to_string(),
                        resolved_value: "The Rolling Stones".to_string(),
                        range: 25..35,
+                       matched_value: "the rolling stones".to_string()
                    },
                    ParsedValue {
-                       raw_value: "the fab four".to_string(),
+                       raw_value: "fab four".to_string(),
                        resolved_value: "The Beatles".to_string(),
-                       range: 40..52,
+                       range: 40..48,
+                       matched_value: "the fab four".to_string(),
                    }]);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 //!     vec![ParsedValue {
 //!         raw_value: "the stones".to_string(),
 //!         resolved_value: "The Rolling Stones".to_string(),
+//!         matched_value: "the rolling stones".to_string(),
 //!         range: 20..30,
 //!     }]
 //! );
@@ -64,6 +65,7 @@
 //!     vec![ParsedValue {
 //!         raw_value: "brel".to_string(),
 //!         resolved_value: "Jacques Brel".to_string(),
+//!         matched_value: "jacques brel".to_string(),
 //!         range: 20..24,
 //!     }]
 //! );


### PR DESCRIPTION
**Description**
This PR introduces a new `matched_value` property in the `ParsedValue` object returned by the main parsing API.
This property corresponds to the underlying matched value which may be different from `raw_value` when the parser threshold is < 1.0.