### PR TITLE
Add a license file to the gazetteer entity parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Add a license file to the gazetteer entity parser [#36](https://github.com/snipsco/gazetteer-entity-parser/pull/36)
+
 ## [0.7.0] - 2019-04-16
 ### Added
 - Add API to prepend entity values [#31](https://github.com/snipsco/gazetteer-entity-parser/pull/31)
@@ -19,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Clearer `ParserBuilder`'s API 
 
+[Unreleased]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.7.0...HEAD
 [0.7.0]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.5.0...0.5.1

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -61,7 +61,6 @@ struct ParserConfig {
     threshold: f32,
     stop_words: HashSet<String>,
     edge_cases: HashSet<String>,
-    license_info: Option<LicenseInfo>,
 }
 
 /// Struct holding a possible match that can be grown by iterating over the input tokens
@@ -408,21 +407,8 @@ impl Parser {
         let reader = fs::File::open(&parser_path)
             .with_context(|_| format_err!("Error when opening the parser file"))?;
 
-        let mut parser: Parser = from_read(reader)
-            .with_context(|_| format_err!("Error when deserializing the parser"))?;
-
-        if let Some(info) = config.license_info {
-            let license_path = folder_name.as_ref().join(&info.filename);
-            let license_content = fs::read_to_string(&license_path)
-                .with_context(|_| format_err!("Error when reading the license"))?;
-
-            parser.license_info = Some(LicenseInfo {
-                content: license_content,
-                filename: info.filename,
-            })
-        };
-
-        Ok(parser)
+        Ok(from_read(reader)
+            .with_context(|_| format_err!("Error when deserializing the parser"))?)
     }
 }
 
@@ -828,7 +814,6 @@ impl Parser {
             threshold: self.threshold,
             stop_words: self.get_stop_words(),
             edge_cases: self.get_edge_cases(),
-            license_info: self.license_info.clone(),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -849,6 +849,16 @@ mod tests {
     use parser_builder::ParserBuilder;
     use std::time::Instant;
 
+    fn get_license_info() -> LicenseInfo {
+        let license_content = "Some content here".to_string();
+        let license_filename = "LICENSE".to_string();
+        let license_info = LicenseInfo {
+            filename: license_filename,
+            content: license_content,
+        };
+        license_info
+    }
+
     #[test]
     fn test_serialization_deserialization() {
         let tdir = tempdir().unwrap();
@@ -866,26 +876,26 @@ mod tests {
             raw_value: "the stones".to_string(),
         });
 
-        let license_filename = "LICENSE".to_string();
-        let license_content = "Some license content\nIn Here".to_string();
+        let license_info = get_license_info();
 
         let parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
             .gazetteer(gazetteer)
             .n_stop_words(2)
             .additional_stop_words(vec!["hello".to_string()])
-            .license_info(license_filename.clone(), license_content.clone())
+            .license_info(license_info)
             .build()
             .unwrap();
 
         let serialized_parser_path = tdir.as_ref().join("parser");
-        let license_path = serialized_parser_path.join(&license_filename);
+        let license_path = serialized_parser_path.join("LICENSE");
         parser.dump(serialized_parser_path).unwrap();
 
         assert!(license_path.exists());
 
+        let expected_content = "Some content here".to_string();
         let content = fs::read_to_string(license_path).unwrap();
-        assert_eq!(content, license_content);
+        assert_eq!(content, expected_content);
 
         let reloaded_parser = Parser::from_folder(tdir.as_ref().join("parser")).unwrap();
 

--- a/src/parser_builder.rs
+++ b/src/parser_builder.rs
@@ -260,8 +260,8 @@ mod tests {
     "world"
   ],
   "license_info": {
-     "filename": "LICENSE",
-     "content": "Some content here"
+    "filename": "LICENSE",
+    "content": "Some content here"
   }
 }"#;
         let mut gazetteer = Gazetteer::default();
@@ -287,24 +287,6 @@ mod tests {
 
         // Serialize builder to string and assert
         let serialized_builder = serde_json::to_string_pretty(&builder).unwrap();
-        let expected_builder_str = r#"{
-  "gazetteer": [
-    {
-      "resolved_value": "yala",
-      "raw_value": "yolo"
-    }
-  ],
-  "threshold": 0.6,
-  "n_gazetteer_stop_words": 30,
-  "additional_stop_words": [
-    "hello",
-    "world"
-  ],
-  "license_info": {
-    "filename": "LICENSE",
-    "content": "Some content here"
-  }
-}"#;
-        assert_eq!(serialized_builder, expected_builder_str);
+        assert_eq!(serialized_builder, serialized_builder_str);
     }
 }

--- a/src/parser_builder.rs
+++ b/src/parser_builder.rs
@@ -302,7 +302,7 @@ mod tests {
   ],
   "license_info": {
     "filename": "LICENSE",
-    "content": " Some content here"
+    "content": "Some content here"
   }
 }"#;
         assert_eq!(serialized_builder, expected_builder_str);

--- a/src/parser_builder.rs
+++ b/src/parser_builder.rs
@@ -71,8 +71,8 @@ impl ParserBuilder {
     }
 
     /// Set the license info
-    pub fn license_info(mut self, filename: String, content: String) -> Self {
-        self.license_info = Some(LicenseInfo { filename, content });
+    pub fn license_info<T: Into<Option<LicenseInfo>>>(mut self, license_info: T) -> Self {
+        self.license_info = license_info.into();
         self
     }
 
@@ -107,6 +107,15 @@ mod tests {
     use super::*;
     use data::EntityValue;
     use serde_json;
+
+    fn get_license_info() -> LicenseInfo {
+        let license_content = "Some content here".to_string();
+        let license_filename = "LICENSE".to_string();
+        LicenseInfo {
+            filename: license_filename,
+            content: license_content,
+        }
+    }
 
     #[test]
     fn test_parser_builder_using_gazetteer() {
@@ -261,14 +270,13 @@ mod tests {
             raw_value: "yolo".to_string(),
         });
 
-        let license_content = "Some content here".to_string();
-        let license_filename = "LICENSE".to_string();
+        let license_info = get_license_info();
 
         let builder = ParserBuilder::default()
             .minimum_tokens_ratio(0.6)
             .gazetteer(gazetteer)
             .n_stop_words(30)
-            .license_info(license_filename, license_content)
+            .license_info(license_info)
             .additional_stop_words(vec!["hello".to_string(), "world".to_string()]);
 
         // Deserialize builder from string and assert result


### PR DESCRIPTION
- Add license information in the parser
- Load and dump license file when needed