### PR TITLE
Alternative resolved values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Changed
+- Add `alternatives` attribute in `ParsedValue` [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
+- Switch `matched_value` and `raw_value` [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
+- Group `resolved_value` and `matched_value` in a dedicated `ResolvedValue` object [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
+
 ## [0.7.2]
 ### Fixed
 - Make `LicenseInfo` public [#38](https://github.com/snipsco/gazetteer-entity-parser/pull/38)
@@ -27,6 +33,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Clearer `ParserBuilder`'s API 
 
+[Unreleased]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.7.2...HEAD
 [0.7.2]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.6.0...0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Changed
+- Add `max_alternatives` parameter to the `Parser::run` API [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
 - Add `alternatives` attribute in `ParsedValue` [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
 - Switch `matched_value` and `raw_value` [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
 - Group `resolved_value` and `matched_value` in a dedicated `ResolvedValue` object [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ criterion = "0.2"
 dinghy-test = "0.4"
 rand = "0.7"
 tempfile = "3"
-mio_httpc = {version = "0.8", features = ["rtls"]}
 clap = "2"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "gazetteer-entity-parser"
 version = "0.7.2"
 authors = ["Alaa Saade <alaa.saade@snips.ai>"]
+repository = "https://github.com/snipsco/gazetteer-entity-parser"
+description = "Gazetteer-based entity parser"
+edition = "2018"
 
 [profile.bench]
 debug = true
@@ -9,8 +12,7 @@ debug = true
 [dependencies]
 failure = "0.1"
 serde_json = "1.0"
-serde_derive = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "0.13"
 fnv = "1.0"
 

--- a/README.rst
+++ b/README.rst
@@ -17,27 +17,15 @@ Example
     use gazetteer_entity_parser::*;
 
     fn main() {
+        let gazetteer = gazetteer!(
+            ("king of pop", "Michael Jackson"),
+            ("the rolling stones", "The Rolling Stones"),
+            ("the beatles", "The Beatles"),
+            ("queen of soul", "Aretha Franklin"),
+            ("the red hot chili peppers", "The Red Hot Chili Peppers"),
+        );
         let parser = ParserBuilder::default()
-            .add_value(EntityValue {
-                raw_value: "king of pop".to_string(),
-                resolved_value: "Michael Jackson".to_string(),
-            })
-            .add_value(EntityValue {
-                raw_value: "the rolling stones".to_string(),
-                resolved_value: "The Rolling Stones".to_string(),
-            })
-            .add_value(EntityValue {
-                raw_value: "the fab four".to_string(),
-                resolved_value: "The Beatles".to_string(),
-            })
-            .add_value(EntityValue {
-                raw_value: "queen of soul".to_string(),
-                resolved_value: "Aretha Franklin".to_string(),
-            })
-            .add_value(EntityValue {
-                raw_value: "the red hot chili peppers".to_string(),
-                resolved_value: "The Red Hot Chili Peppers".to_string(),
-            })
+            .gazetteer(gazetteer)
             .minimum_tokens_ratio(2. / 3.)
             .build()
             .unwrap();

--- a/benches/bench_parser.rs
+++ b/benches/bench_parser.rs
@@ -118,14 +118,14 @@ fn get_high_redundancy_parser() -> (Parser, RandomStringGenerator) {
 fn parsing_low_redundancy(c: &mut Criterion) {
     let (parser, mut rsg) = get_low_redundancy_parser();
     c.bench_function("Parse random value - low redundancy", move |b| {
-        b.iter(|| parser.run(&rsg.next().unwrap()))
+        b.iter(|| parser.run(&rsg.next().unwrap(), 10))
     });
 }
 
 fn parsing_high_redundancy(c: &mut Criterion) {
     let (parser, mut rsg) = get_high_redundancy_parser();
     c.bench_function("Parse random value - high redundancy", move |b| {
-        b.iter(|| parser.run(&rsg.next().unwrap()))
+        b.iter(|| parser.run(&rsg.next().unwrap(), 10))
     });
 }
 

--- a/examples/entity_parsing_from_scratch.rs
+++ b/examples/entity_parsing_from_scratch.rs
@@ -17,7 +17,7 @@ fn main() {
         .unwrap();
 
     let sentence = "My favourite artists are the stones and fab four";
-    let extracted_entities = parser.run(sentence).unwrap();
+    let extracted_entities = parser.run(sentence, 5).unwrap();
     assert_eq!(
         extracted_entities,
         vec![

--- a/examples/entity_parsing_from_scratch.rs
+++ b/examples/entity_parsing_from_scratch.rs
@@ -3,27 +3,15 @@ extern crate gazetteer_entity_parser;
 use gazetteer_entity_parser::*;
 
 fn main() {
+    let gazetteer = gazetteer!(
+        ("king of pop", "Michael Jackson"),
+        ("the rolling stones", "The Rolling Stones"),
+        ("the fab four", "The Beatles"),
+        ("queen of soul", "Aretha Franklin"),
+        ("the red hot chili peppers", "The Red Hot Chili Peppers"),
+    );
     let parser = ParserBuilder::default()
-        .add_value(EntityValue {
-            raw_value: "king of pop".to_string(),
-            resolved_value: "Michael Jackson".to_string(),
-        })
-        .add_value(EntityValue {
-            raw_value: "the rolling stones".to_string(),
-            resolved_value: "The Rolling Stones".to_string(),
-        })
-        .add_value(EntityValue {
-            raw_value: "the fab four".to_string(),
-            resolved_value: "The Beatles".to_string(),
-        })
-        .add_value(EntityValue {
-            raw_value: "queen of soul".to_string(),
-            resolved_value: "Aretha Franklin".to_string(),
-        })
-        .add_value(EntityValue {
-            raw_value: "the red hot chili peppers".to_string(),
-            resolved_value: "The Red Hot Chili Peppers".to_string(),
-        })
+        .gazetteer(gazetteer)
         .minimum_tokens_ratio(2. / 3.)
         .build()
         .unwrap();
@@ -34,19 +22,19 @@ fn main() {
         extracted_entities,
         vec![
             ParsedValue {
-                raw_value: "the stones".to_string(),
+                matched_value: "the stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 25..35,
             },
             ParsedValue {
-                raw_value: "fab four".to_string(),
+                matched_value: "fab four".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Beatles".to_string(),
-                    matched_value: "the fab four".to_string(),
+                    raw_value: "the fab four".to_string(),
                 },
                 alternatives: vec![],
                 range: 40..48,

--- a/examples/entity_parsing_from_scratch.rs
+++ b/examples/entity_parsing_from_scratch.rs
@@ -30,18 +30,27 @@ fn main() {
 
     let sentence = "My favourite artists are the stones and fab four";
     let extracted_entities = parser.run(sentence).unwrap();
-    assert_eq!(extracted_entities,
-               vec![
-                   ParsedValue {
-                       raw_value: "the stones".to_string(),
-                       resolved_value: "The Rolling Stones".to_string(),
-                       range: 25..35,
-                       matched_value: "the rolling stones".to_string()
-                   },
-                   ParsedValue {
-                       raw_value: "fab four".to_string(),
-                       resolved_value: "The Beatles".to_string(),
-                       range: 40..48,
-                       matched_value: "the fab four".to_string(),
-                   }]);
+    assert_eq!(
+        extracted_entities,
+        vec![
+            ParsedValue {
+                raw_value: "the stones".to_string(),
+                resolved_value: ResolvedValue {
+                    resolved: "The Rolling Stones".to_string(),
+                    matched_value: "the rolling stones".to_string(),
+                },
+                alternatives: vec![],
+                range: 25..35,
+            },
+            ParsedValue {
+                raw_value: "fab four".to_string(),
+                resolved_value: ResolvedValue {
+                    resolved: "The Beatles".to_string(),
+                    matched_value: "the fab four".to_string(),
+                },
+                alternatives: vec![],
+                range: 40..48,
+            }
+        ]
+    );
 }

--- a/examples/interactive_parsing_cli.rs
+++ b/examples/interactive_parsing_cli.rs
@@ -39,6 +39,13 @@ fn main() {
                 .long("--ratio")
                 .takes_value(true)
                 .help("minimum tokens ratio for the parser"),
+        )
+        .arg(
+            Arg::with_name("opt_max_alternatives")
+                .short("a")
+                .long("--alternatives")
+                .takes_value(true)
+                .help("maximum number of alternative resolved values"),
         );
     let matches = app.clone().get_matches();
 
@@ -49,6 +56,10 @@ fn main() {
     let opt_tokens_ratio = matches
         .value_of("opt_tokens_ratio")
         .map(|ratio_str| ratio_str.to_string().parse::<f32>().unwrap());
+    let max_alternatives = matches
+        .value_of("opt_max_alternatives")
+        .map(|max_str| max_str.to_string().parse::<usize>().unwrap())
+        .unwrap_or(5);
 
     if let Some(parser) = matches
         .value_of("parser")
@@ -84,7 +95,7 @@ fn main() {
             io::stdout().flush().unwrap();
             let mut query = String::new();
             io::stdin().read_line(&mut query).unwrap();
-            let result = parser.run(query.trim()).unwrap();
+            let result = parser.run(query.trim(), max_alternatives).unwrap();
             println!("{:?}", result);
         }
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,17 +79,6 @@
 //!     }]
 //! );
 //!```
-
-#[macro_use]
-extern crate failure;
-extern crate fnv;
-extern crate rmp_serde as rmps;
-extern crate serde;
-extern crate serde_json;
-
-#[macro_use]
-extern crate serde_derive;
-
 mod constants;
 mod data;
 mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //!```rust
 //!
-//! use gazetteer_entity_parser::{Gazetteer, ParserBuilder, EntityValue, ParsedValue, ResolvedValue};
+//! use gazetteer_entity_parser::{gazetteer, Gazetteer, ParserBuilder, EntityValue, ParsedValue, ResolvedValue};
 //!
 //! let mut gazetteer = Gazetteer::default();
 //! // We fill the gazetteer with artists, sorted by popularity
@@ -36,6 +36,15 @@
 //!     raw_value: "daniel brel".to_string(),
 //! });
 //!
+//! // Alternatively the gazetteer can be created with the `gazetteer!()` macro
+//! gazetteer = gazetteer!(
+//!     ("the rolling stones", "The Rolling Stones"),
+//!     ("the strokes", "The Strokes"),
+//!     ("the hives", "The Hives"),
+//!     ("jacques brel", "Jacques Brel"),
+//!     ("daniel brel", "Daniel Brel"),
+//! );
+//!
 //! // The Parser is then instantiated using a builder pattern. The ParserBuilder is instantiated
 //! // from a gazetteer and a decoding threshold, i.e. the minimal fraction of matched tokens for
 //! // a parsing to be possible. Additional methods allow to set the stop words of the Parser,
@@ -46,8 +55,11 @@
 //!     .n_stop_words(1)
 //!     .additional_stop_words(vec!["a".to_string(), "for".to_string()]).build().unwrap();
 //!
+//! // Maximum number of alternative resolved values to return
+//! let max_alternatives = 5;
+//!
 //! // Parse a sentence
-//! let parsed_stones = parser.run("I want to listen to the stones").unwrap();
+//! let parsed_stones = parser.run("I want to listen to the stones", max_alternatives).unwrap();
 //! assert_eq!(
 //!     parsed_stones,
 //!     vec![ParsedValue {
@@ -62,7 +74,7 @@
 //! );
 //!
 //! // Example with an ambiguity, where the artist with smaller rank is preferred
-//! let parsed_brel = parser.run("I want to listen to brel").unwrap();
+//! let parsed_brel = parser.run("I want to listen to brel", max_alternatives).unwrap();
 //! assert_eq!(
 //!     parsed_brel,
 //!     vec![ParsedValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //!```rust
 //!
-//! use gazetteer_entity_parser::{Gazetteer, ParserBuilder, EntityValue, ParsedValue};
+//! use gazetteer_entity_parser::{Gazetteer, ParserBuilder, EntityValue, ParsedValue, ResolvedValue};
 //!
 //! let mut gazetteer = Gazetteer::default();
 //! // We fill the gazetteer with artists, sorted by popularity
@@ -52,8 +52,11 @@
 //!     parsed_stones,
 //!     vec![ParsedValue {
 //!         raw_value: "the stones".to_string(),
-//!         resolved_value: "The Rolling Stones".to_string(),
-//!         matched_value: "the rolling stones".to_string(),
+//!         resolved_value: ResolvedValue {
+//!             resolved: "The Rolling Stones".to_string(),
+//!             matched_value: "the rolling stones".to_string()
+//!         },
+//!         alternatives: vec![],
 //!         range: 20..30,
 //!     }]
 //! );
@@ -64,8 +67,11 @@
 //!     parsed_brel,
 //!     vec![ParsedValue {
 //!         raw_value: "brel".to_string(),
-//!         resolved_value: "Jacques Brel".to_string(),
-//!         matched_value: "jacques brel".to_string(),
+//!         resolved_value: ResolvedValue {
+//!             resolved: "Jacques Brel".to_string(),
+//!             matched_value: "jacques brel".to_string()
+//!         },
+//!         alternatives: vec![],
 //!         range: 20..24,
 //!     }]
 //! );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,10 @@
 //! assert_eq!(
 //!     parsed_stones,
 //!     vec![ParsedValue {
-//!         raw_value: "the stones".to_string(),
+//!         matched_value: "the stones".to_string(),
 //!         resolved_value: ResolvedValue {
 //!             resolved: "The Rolling Stones".to_string(),
-//!             matched_value: "the rolling stones".to_string()
+//!             raw_value: "the rolling stones".to_string()
 //!         },
 //!         alternatives: vec![],
 //!         range: 20..30,
@@ -66,12 +66,15 @@
 //! assert_eq!(
 //!     parsed_brel,
 //!     vec![ParsedValue {
-//!         raw_value: "brel".to_string(),
+//!         matched_value: "brel".to_string(),
 //!         resolved_value: ResolvedValue {
 //!             resolved: "Jacques Brel".to_string(),
-//!             matched_value: "jacques brel".to_string()
+//!             raw_value: "jacques brel".to_string()
 //!         },
-//!         alternatives: vec![],
+//!         alternatives: vec![ResolvedValue {
+//!             resolved: "Daniel Brel".to_string(),
+//!             raw_value: "daniel brel".to_string()
+//!         }],
 //!         range: 20..24,
 //!     }]
 //! );
@@ -98,3 +101,5 @@ pub use data::*;
 pub use parser::*;
 pub use parser_builder::*;
 pub mod errors;
+#[macro_use]
+pub mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,13 @@
+#[macro_export]
+macro_rules! gazetteer {
+    ($(($raw:expr, $resolved:expr),)*) => {{
+        let mut gazetteer = Gazetteer::default();
+        $(
+            gazetteer.add(EntityValue {
+                raw_value: $raw.to_string(),
+                resolved_value: $resolved.to_string(),
+            });
+        )*
+        gazetteer
+    }}
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -145,9 +145,9 @@ impl Ord for ParsedValue {
 
 impl PartialOrd for ParsedValue {
     fn partial_cmp(&self, other: &ParsedValue) -> Option<Ordering> {
-        if self.range.end < other.range.start {
+        if self.range.end <= other.range.start {
             Some(Ordering::Less)
-        } else if self.range.start > other.range.end {
+        } else if self.range.start >= other.range.end {
             Some(Ordering::Greater)
         } else {
             None
@@ -356,8 +356,8 @@ impl Parser {
             // we inject new values from rank 0 to n_new_values - 1
             true => 0,
             // we inject new values from the current last rank onwards
-            false => self.resolved_value_to_tokens.len(),
-        } as u32;
+            false => self.resolved_value_to_tokens.len() as u32,
+        };
 
         for (rank, entity_value) in new_values.into_iter().enumerate() {
             self.add_value(entity_value.clone(), new_start_rank + rank as u32);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,7 +75,8 @@ pub struct PossibleMatch {
     first_token_in_resolution: usize,
     last_token_in_resolution: usize,
     rank: u32,
-    alternative_resolved_values: Vec<(u32, usize)>,
+    // List of tuples (resolved_value_idx, rank)
+    alternative_resolved_values: Vec<(u32, u32)>,
 }
 
 impl PossibleMatch {
@@ -121,13 +122,13 @@ pub struct ParsedValue {
     pub alternatives: Vec<ResolvedValue>,
     // character-level
     pub range: Range<usize>,
-    pub raw_value: String,
+    pub matched_value: String,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct ResolvedValue {
     pub resolved: String,
-    pub matched_value: String,
+    pub raw_value: String,
 }
 
 impl Ord for ParsedValue {
@@ -463,7 +464,7 @@ impl Parser {
             .join(" ");
         Ok(ResolvedValue {
             resolved,
-            matched_value,
+            raw_value: matched_value,
         })
     }
 
@@ -474,9 +475,8 @@ impl Parser {
         input: &str,
         threshold: f32,
     ) -> Result<BinaryHeap<PossibleMatch>> {
-        let mut possible_matches: HashMap<u32, PossibleMatch> =
-            HashMap::with_capacity_and_hasher(1000, Default::default());
-        let mut matches_heap: BinaryHeap<PossibleMatch> = BinaryHeap::default();
+        let mut partial_matches: HashMap<u32, PossibleMatch> = HashMap::default();
+        let mut final_matches: Vec<PossibleMatch> = vec![];
         let mut skipped_tokens: HashMap<usize, (Range<usize>, u32)> = HashMap::default();
         for (token_idx, (range, token)) in whitespace_tokenizer(input).enumerate() {
             if let Some(value) = self.tokens_symbol_table.find_symbol(&token) {
@@ -491,8 +491,8 @@ impl Parser {
                             *res_val,
                             token_idx,
                             range.clone(),
-                            &mut possible_matches,
-                            &mut matches_heap,
+                            &mut partial_matches,
+                            &mut final_matches,
                             &mut skipped_tokens,
                             threshold,
                         )?;
@@ -508,8 +508,8 @@ impl Parser {
                                 *res_val,
                                 token_idx,
                                 range.clone(),
-                                &mut possible_matches,
-                                &mut matches_heap,
+                                &mut partial_matches,
+                                &mut final_matches,
                                 &mut skipped_tokens,
                                 1.0,
                             )?;
@@ -519,7 +519,7 @@ impl Parser {
                     // Iterate over current possible matches containing the stop word and
                     // try to grow them (but do not initiate a new possible match)
                     // Threshold depends on whether the res_val is an edge case or not
-                    for (res_val, mut possible_match) in &mut possible_matches {
+                    for (res_val, mut possible_match) in &mut partial_matches {
                         if !res_vals_from_token.contains(res_val)
                             || self.edge_cases.contains(res_val)
                         {
@@ -531,7 +531,7 @@ impl Parser {
                             *value,
                             range.clone(),
                             threshold,
-                            &mut matches_heap,
+                            &mut final_matches,
                         )?;
                     }
                 }
@@ -539,7 +539,7 @@ impl Parser {
         }
 
         // Add to the heap the possible matches that remain
-        let mut matches_heap = possible_matches
+        let final_matches = partial_matches
             .values()
             .filter(|possible_match| {
                 if self.edge_cases.contains(&possible_match.resolved_value) {
@@ -548,29 +548,14 @@ impl Parser {
                     possible_match.check_threshold(threshold)
                 }
             })
-            .fold(matches_heap, |mut acc, possible_match| {
+            .fold(final_matches, |mut acc, possible_match| {
                 acc.push(possible_match.clone());
                 acc
             });
-        Ok(matches_heap)
-    }
 
-    //    fn group_matches(mut matches_heap: BinaryHeap<PossibleMatch>) -> BinaryHeap<PossibleMatch> {
-    //        let mut grouped_matches = BinaryHeap::default();
-    //        let mut opt_previous_match: Option<PossibleMatch> = None;
-    //        while !matches_heap.is_empty() {
-    //            let possible_match = matches_heap.pop().unwrap();
-    //            match opt_previous_match {
-    //                Some(previous_match) => {
-    //                    if previous_match.range == possible_match.range {
-    //                        previous_match
-    //                    }
-    //                },
-    //                None => opt_previous_match = Some(possible_match)
-    //            }
-    //        }
-    //        grouped_matches
-    //    }
+        // Group possible matches that matched the same underlying range
+        Ok(group_matches(final_matches))
+    }
 
     fn update_or_insert_possible_match(
         &self,
@@ -578,12 +563,12 @@ impl Parser {
         res_val: u32,
         token_idx: usize,
         range: Range<usize>,
-        possible_matches: &mut HashMap<u32, PossibleMatch>,
-        mut matches_heap: &mut BinaryHeap<PossibleMatch>,
+        partial_matches: &mut HashMap<u32, PossibleMatch>,
+        mut final_matches: &mut Vec<PossibleMatch>,
         skipped_tokens: &mut HashMap<usize, (Range<usize>, u32)>,
         threshold: f32,
     ) -> Result<()> {
-        match possible_matches.entry(res_val) {
+        match partial_matches.entry(res_val) {
             Entry::Occupied(mut entry) => {
                 self.update_previous_match(
                     entry.get_mut(),
@@ -591,7 +576,7 @@ impl Parser {
                     value,
                     range,
                     threshold,
-                    &mut matches_heap,
+                    &mut final_matches,
                 )?;
             }
             Entry::Vacant(entry) => {
@@ -618,7 +603,7 @@ impl Parser {
         value: u32,
         range: Range<usize>,
         threshold: f32,
-        ref mut matches_heap: &mut BinaryHeap<PossibleMatch>,
+        ref mut final_matches: &mut Vec<PossibleMatch>,
     ) -> Result<()> {
         let (rank, otokens) =
             self.get_tokens_from_resolved_value(&possible_match.resolved_value)?;
@@ -645,7 +630,7 @@ impl Parser {
         // We start a new PossibleMatch.
 
         if possible_match.check_threshold(threshold) {
-            matches_heap.push(possible_match.clone());
+            final_matches.push(possible_match.clone());
         }
         // Then we initialize a new PossibleMatch with the same res val
         let last_token_in_resolution =
@@ -813,7 +798,7 @@ impl Parser {
 
             parsing.push(ParsedValue {
                 range: possible_match.range.clone(),
-                raw_value: input
+                matched_value: input
                     .chars()
                     .skip(possible_match.range.start)
                     .take(possible_match.range.len())
@@ -845,21 +830,52 @@ impl Parser {
     }
 }
 
+fn group_matches(final_matches: Vec<PossibleMatch>) -> BinaryHeap<PossibleMatch> {
+    final_matches
+        .iter()
+        .fold(
+            HashMap::<Range<usize>, BinaryHeap<&PossibleMatch>>::default(),
+            |mut grouped_matches, final_match| {
+                grouped_matches
+                    .entry(final_match.range.clone())
+                    .and_modify(|entry| entry.push(final_match))
+                    .or_insert_with(|| {
+                        let mut alternatives = BinaryHeap::new();
+                        alternatives.push(final_match);
+                        alternatives
+                    });
+                grouped_matches
+            },
+        )
+        .into_iter()
+        .map(|(_, mut matches)| {
+            let mut best_match = matches.pop().unwrap().clone();
+            while !matches.is_empty() {
+                let m = matches.pop().unwrap();
+                // Only add alternative with the same matching ratio
+                if m.raw_value_length > best_match.raw_value_length {
+                    break;
+                }
+                best_match
+                    .alternative_resolved_values
+                    .push((m.resolved_value, m.rank));
+            }
+            best_match
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
-    extern crate mio_httpc;
     extern crate tempfile;
 
-    use self::mio_httpc::CallBuilder;
     use self::tempfile::tempdir;
-    #[allow(unused_imports)]
     use super::*;
-    #[allow(unused_imports)]
+    use crate::gazetteer;
     use data::EntityValue;
     use data::Gazetteer;
     use failure::ResultExt;
     use parser_builder::ParserBuilder;
-    use std::time::Instant;
 
     fn get_license_info() -> LicenseInfo {
         let license_content = "Some content here".to_string();
@@ -874,19 +890,11 @@ mod tests {
     #[test]
     fn test_serialization_deserialization() {
         let tdir = tempdir().unwrap();
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Flying Stones".to_string(),
-            raw_value: "the flying stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the stones".to_string(),
-        });
+        let gazetteer = gazetteer!(
+            ("the flying stones", "The Flying Stones"),
+            ("the rolling stones", "The Rolling Stones"),
+            ("the stones", "The Rolling Stones"),
+        );
 
         let license_info = get_license_info();
 
@@ -935,24 +943,12 @@ mod tests {
 
     #[test]
     fn test_stop_words_and_edge_cases() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Flying Stones".to_string(),
-            raw_value: "the flying stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Stones Rolling".to_string(),
-            raw_value: "the stones rolling".to_string(),
-        });
-
-        gazetteer.add(EntityValue {
-            resolved_value: "The Stones".to_string(),
-            raw_value: "the stones".to_string(),
-        });
+        let gazetteer = gazetteer!(
+            ("the flying stones", "The Flying Stones"),
+            ("the rolling stones", "The Rolling Stones"),
+            ("the stones rolling", "The Stones Rolling"),
+            ("the stones", "The Stones"),
+        );
 
         let mut parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
@@ -977,12 +973,15 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the rolling".to_string(),
+                matched_value: "the rolling".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string()
+                    raw_value: "the rolling stones".to_string()
                 },
-                alternatives: vec![],
+                alternatives: vec![ResolvedValue {
+                    resolved: "The Stones Rolling".to_string(),
+                    raw_value: "the stones rolling".to_string()
+                }],
                 range: 20..31,
             }]
         );
@@ -995,10 +994,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the rolling stones".to_string(),
+                matched_value: "the rolling stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 20..38,
@@ -1013,10 +1012,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the stones rolling".to_string(),
+                matched_value: "the stones rolling".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Stones Rolling".to_string(),
-                    matched_value: "the stones rolling".to_string(),
+                    raw_value: "the stones rolling".to_string(),
                 },
                 alternatives: vec![],
                 range: 20..38,
@@ -1029,10 +1028,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the stones".to_string(),
+                matched_value: "the stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Stones".to_string(),
-                    matched_value: "the stones".to_string(),
+                    raw_value: "the stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 20..30,
@@ -1051,10 +1050,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the rolling stones".to_string(),
+                matched_value: "the rolling stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 26..44,
@@ -1068,10 +1067,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the rolling stones".to_string(),
+                matched_value: "the rolling stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 30..48,
@@ -1081,23 +1080,12 @@ mod tests {
 
     #[test]
     fn test_parser_base() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Flying Stones".to_string(),
-            raw_value: "the flying stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Blink-182".to_string(),
-            raw_value: "blink one eight two".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Je Suis Animal".to_string(),
-            raw_value: "je suis animal".to_string(),
-        });
+        let gazetteer = gazetteer!(
+            ("the flying stones", "The Flying Stones"),
+            ("the rolling stones", "The Rolling Stones"),
+            ("blink one eight two", "Blink-182"),
+            ("je suis animal", "Je Suis Animal"),
+        );
 
         let parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.0)
@@ -1110,19 +1098,19 @@ mod tests {
             parsed,
             vec![
                 ParsedValue {
-                    raw_value: "je".to_string(),
+                    matched_value: "je".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "Je Suis Animal".to_string(),
-                        matched_value: "je suis animal".to_string(),
+                        raw_value: "je suis animal".to_string(),
                     },
                     alternatives: vec![],
                     range: 0..2,
                 },
                 ParsedValue {
-                    raw_value: "rolling stones".to_string(),
+                    matched_value: "rolling stones".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "The Rolling Stones".to_string(),
-                        matched_value: "the rolling stones".to_string(),
+                        raw_value: "the rolling stones".to_string(),
                     },
                     alternatives: vec![],
                     range: 20..34,
@@ -1135,19 +1123,19 @@ mod tests {
             parsed,
             vec![
                 ParsedValue {
-                    raw_value: "je".to_string(),
+                    matched_value: "je".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "Je Suis Animal".to_string(),
-                        matched_value: "je suis animal".to_string(),
+                        raw_value: "je suis animal".to_string(),
                     },
                     alternatives: vec![],
                     range: 0..2,
                 },
                 ParsedValue {
-                    raw_value: "rolling stones".to_string(),
+                    matched_value: "rolling stones".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "The Rolling Stones".to_string(),
-                        matched_value: "the rolling stones".to_string(),
+                        raw_value: "the rolling stones".to_string(),
                     },
                     alternatives: vec![],
                     range: 22..36,
@@ -1162,19 +1150,19 @@ mod tests {
             parsed,
             vec![
                 ParsedValue {
-                    raw_value: "rolling stones".to_string(),
+                    matched_value: "rolling stones".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "The Rolling Stones".to_string(),
-                        matched_value: "the rolling stones".to_string(),
+                        raw_value: "the rolling stones".to_string(),
                     },
                     alternatives: vec![],
                     range: 20..34,
                 },
                 ParsedValue {
-                    raw_value: "blink eight".to_string(),
+                    matched_value: "blink eight".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "Blink-182".to_string(),
-                        matched_value: "blink one eight two".to_string(),
+                        raw_value: "blink one eight two".to_string(),
                     },
                     alternatives: vec![],
                     range: 39..50,
@@ -1188,19 +1176,11 @@ mod tests {
 
     #[test]
     fn test_parser_multiple_raw_values() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "Blink-182".to_string(),
-            raw_value: "blink one eight two".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Blink-182".to_string(),
-            raw_value: "blink 182".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Blink-182".to_string(),
-            raw_value: "blink".to_string(),
-        });
+        let gazetteer = gazetteer!(
+            ("blink one eight two", "Blink-182"),
+            ("blink 182", "Blink-182"),
+            ("blink", "Blink-182"),
+        );
 
         let mut parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.0)
@@ -1212,10 +1192,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "blink 182".to_string(),
+                matched_value: "blink 182".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "Blink-182".to_string(),
-                    matched_value: "blink 182".to_string(),
+                    raw_value: "blink 182".to_string(),
                 },
                 alternatives: vec![],
                 range: 16..25,
@@ -1227,10 +1207,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "blink".to_string(),
+                matched_value: "blink".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "Blink-182".to_string(),
-                    matched_value: "blink".to_string(),
+                    raw_value: "blink".to_string(),
                 },
                 alternatives: vec![],
                 range: 16..21,
@@ -1242,10 +1222,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "one eight two".to_string(),
+                matched_value: "one eight two".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "Blink-182".to_string(),
-                    matched_value: "blink one eight two".to_string(),
+                    raw_value: "blink one eight two".to_string(),
                 },
                 alternatives: vec![],
                 range: 16..29,
@@ -1255,27 +1235,14 @@ mod tests {
 
     #[test]
     fn test_parser_with_ranking() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "Jacques Brel".to_string(),
-            raw_value: "jacques brel".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Flying Stones".to_string(),
-            raw_value: "the flying stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Daniel Brel".to_string(),
-            raw_value: "daniel brel".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Jacques".to_string(),
-            raw_value: "jacques".to_string(),
-        });
+        let gazetteer = gazetteer!(
+            ("jacques brel", "Jacques Brel"),
+            ("the rolling stones", "The Rolling Stones"),
+            ("the flying stones", "The Flying Stones"),
+            ("daniel brel", "Daniel Brel"),
+            ("jacques", "Jacques"),
+        );
+
         let parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
             .gazetteer(gazetteer)
@@ -1287,27 +1254,16 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the stones".to_string(),
+                matched_value: "the stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
-                alternatives: vec![],
+                alternatives: vec![ResolvedValue {
+                    resolved: "The Flying Stones".to_string(),
+                    raw_value: "the flying stones".to_string(),
+                }],
                 range: 16..26,
-            }]
-        );
-
-        let parsed = parser.run("je veux écouter brel").unwrap();
-        assert_eq!(
-            parsed,
-            vec![ParsedValue {
-                raw_value: "brel".to_string(),
-                resolved_value: ResolvedValue {
-                    resolved: "Jacques Brel".to_string(),
-                    matched_value: "jacques brel".to_string(),
-                },
-                alternatives: vec![],
-                range: 16..20,
             }]
         );
 
@@ -1316,38 +1272,25 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the flying stones".to_string(),
+                matched_value: "the flying stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Flying Stones".to_string(),
-                    matched_value: "the flying stones".to_string(),
+                    raw_value: "the flying stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 16..33,
             }]
         );
 
-        let parsed = parser.run("je veux écouter daniel brel").unwrap();
-        assert_eq!(
-            parsed,
-            vec![ParsedValue {
-                raw_value: "daniel brel".to_string(),
-                resolved_value: ResolvedValue {
-                    resolved: "Daniel Brel".to_string(),
-                    matched_value: "daniel brel".to_string(),
-                },
-                alternatives: vec![],
-                range: 16..27,
-            }]
-        );
-
+        // Resolve to the value with the best matching ratio
         let parsed = parser.run("je veux écouter jacques").unwrap();
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "jacques".to_string(),
+                matched_value: "jacques".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "Jacques".to_string(),
-                    matched_value: "jacques".to_string(),
+                    raw_value: "jacques".to_string(),
                 },
                 alternatives: vec![],
                 range: 16..23,
@@ -1357,15 +1300,10 @@ mod tests {
 
     #[test]
     fn test_preprend_values() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "Jacques Brel".to_string(),
-            raw_value: "jacques brel".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
+        let gazetteer = gazetteer!(
+            ("jacques brel", "Jacques Brel"),
+            ("the rolling stones", "The Rolling Stones"),
+        );
         let mut parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
             .gazetteer(gazetteer)
@@ -1378,10 +1316,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "brel".to_string(),
+                matched_value: "brel".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "Jacques Brel".to_string(),
-                    matched_value: "jacques brel".to_string(),
+                    raw_value: "jacques brel".to_string(),
                 },
                 alternatives: vec![],
                 range: 16..20,
@@ -1405,12 +1343,21 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "brel".to_string(),
+                matched_value: "brel".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "Daniel Brel".to_string(),
-                    matched_value: "daniel brel".to_string(),
+                    raw_value: "daniel brel".to_string(),
                 },
-                alternatives: vec![],
+                alternatives: vec![
+                    ResolvedValue {
+                        resolved: "Eric Brel".to_string(),
+                        raw_value: "eric brel".to_string(),
+                    },
+                    ResolvedValue {
+                        resolved: "Jacques Brel".to_string(),
+                        raw_value: "jacques brel".to_string(),
+                    }
+                ],
                 range: 16..20,
             }]
         );
@@ -1418,12 +1365,7 @@ mod tests {
 
     #[test]
     fn test_parser_with_restart() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-
+        let gazetteer = gazetteer!(("the rolling stones", "The Rolling Stones"),);
         let parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
             .gazetteer(gazetteer)
@@ -1438,11 +1380,7 @@ mod tests {
 
     #[test]
     fn test_parser_with_unicode_whitespace() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "Quand est-ce ?".to_string(),
-            raw_value: "quand est -ce".to_string(),
-        });
+        let gazetteer = gazetteer!(("quand est -ce", "Quand est-ce ?"),);
         let parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
             .gazetteer(gazetteer)
@@ -1455,10 +1393,10 @@ mod tests {
             vec![ParsedValue {
                 resolved_value: ResolvedValue {
                     resolved: "Quand est-ce ?".to_string(),
-                    matched_value: "quand est -ce".to_string(),
+                    raw_value: "quand est -ce".to_string(),
                 },
                 range: 4..13,
-                raw_value: "quand est".to_string(),
+                matched_value: "quand est".to_string(),
                 alternatives: vec![],
             }]
         )
@@ -1466,12 +1404,7 @@ mod tests {
 
     #[test]
     fn test_parser_with_mixed_ordered_entity() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-
+        let gazetteer = gazetteer!(("the rolling stones", "The Rolling Stones"),);
         let parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
             .gazetteer(gazetteer)
@@ -1484,10 +1417,10 @@ mod tests {
             vec![ParsedValue {
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
                 range: 8..18,
-                raw_value: "the stones".to_string(),
+                matched_value: "the stones".to_string(),
                 alternatives: vec![],
             }]
         );
@@ -1495,27 +1428,13 @@ mod tests {
 
     #[test]
     fn test_parser_with_threshold() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Flying Stones".to_string(),
-            raw_value: "the flying stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Blink-182".to_string(),
-            raw_value: "blink one eight two".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Je Suis Animal".to_string(),
-            raw_value: "je suis animal".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Les Enfoirés".to_string(),
-            raw_value: "les enfoirés".to_string(),
-        });
+        let gazetteer = gazetteer!(
+            ("the flying stones", "The Flying Stones"),
+            ("the rolling stones", "The Rolling Stones"),
+            ("blink one eight two", "Blink-182"),
+            ("je suis animal", "Je Suis Animal"),
+            ("les enfoirés", "Les Enfoirés"),
+        );
 
         let mut parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
@@ -1530,17 +1449,17 @@ mod tests {
                 ParsedValue {
                     resolved_value: ResolvedValue {
                         resolved: "Les Enfoirés".to_string(),
-                        matched_value: "les enfoirés".to_string(),
+                        raw_value: "les enfoirés".to_string(),
                     },
                     range: 16..19,
-                    raw_value: "les".to_string(),
+                    matched_value: "les".to_string(),
                     alternatives: vec![],
                 },
                 ParsedValue {
-                    raw_value: "rolling stones".to_string(),
+                    matched_value: "rolling stones".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "The Rolling Stones".to_string(),
-                        matched_value: "the rolling stones".to_string(),
+                        raw_value: "the rolling stones".to_string(),
                     },
                     alternatives: vec![],
                     range: 20..34,
@@ -1554,10 +1473,10 @@ mod tests {
             parsed,
             vec![
                 ParsedValue {
-                    raw_value: "je".to_string(),
+                    matched_value: "je".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "Je Suis Animal".to_string(),
-                        matched_value: "je suis animal".to_string(),
+                        raw_value: "je suis animal".to_string(),
                     },
                     alternatives: vec![],
                     range: 0..2,
@@ -1565,17 +1484,17 @@ mod tests {
                 ParsedValue {
                     resolved_value: ResolvedValue {
                         resolved: "Les Enfoirés".to_string(),
-                        matched_value: "les enfoirés".to_string(),
+                        raw_value: "les enfoirés".to_string(),
                     },
                     alternatives: vec![],
                     range: 16..19,
-                    raw_value: "les".to_string(),
+                    matched_value: "les".to_string(),
                 },
                 ParsedValue {
-                    raw_value: "rolling stones".to_string(),
+                    matched_value: "rolling stones".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "The Rolling Stones".to_string(),
-                        matched_value: "the rolling stones".to_string(),
+                        raw_value: "the rolling stones".to_string(),
                     },
                     alternatives: vec![],
                     range: 20..34,
@@ -1588,10 +1507,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "rolling stones".to_string(),
+                matched_value: "rolling stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 20..34,
@@ -1601,12 +1520,7 @@ mod tests {
 
     #[test]
     fn test_repeated_words() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-
+        let gazetteer = gazetteer!(("the rolling stones", "The Rolling Stones"),);
         let mut parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.5)
             .gazetteer(gazetteer)
@@ -1623,10 +1537,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the rolling stones".to_string(),
+                matched_value: "the rolling stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 8..26,
@@ -1636,12 +1550,7 @@ mod tests {
 
     #[test]
     fn test_injection_ranking() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-
+        let gazetteer = gazetteer!(("the rolling stones", "The Rolling Stones"),);
         let mut parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.6)
             .gazetteer(gazetteer)
@@ -1662,10 +1571,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "flying stones".to_string(),
+                matched_value: "flying stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Flying Stones".to_string(),
-                    matched_value: "the flying stones".to_string(),
+                    raw_value: "the flying stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 20..33,
@@ -1677,28 +1586,31 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the stones".to_string(),
+                matched_value: "the stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
                 },
-                alternatives: vec![],
+                alternatives: vec![ResolvedValue {
+                    resolved: "The Flying Stones".to_string(),
+                    raw_value: "the flying stones".to_string(),
+                }],
                 range: 16..26,
             }]
         );
 
         // Test with preprend set to true
-        parser.inject_new_values(new_values, true, false).unwrap();
+        parser.inject_new_values(new_values, true, true).unwrap();
 
         let parsed = parser.run("je veux écouter les flying stones").unwrap();
 
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "flying stones".to_string(),
+                matched_value: "flying stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Flying Stones".to_string(),
-                    matched_value: "the flying stones".to_string(),
+                    raw_value: "the flying stones".to_string(),
                 },
                 alternatives: vec![],
                 range: 20..33,
@@ -1710,12 +1622,15 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "the stones".to_string(),
+                matched_value: "the stones".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Flying Stones".to_string(),
-                    matched_value: "the flying stones".to_string(),
+                    raw_value: "the flying stones".to_string(),
                 },
-                alternatives: vec![],
+                alternatives: vec![ResolvedValue {
+                    resolved: "The Rolling Stones".to_string(),
+                    raw_value: "the rolling stones".to_string(),
+                }],
                 range: 16..26,
             }]
         );
@@ -1723,12 +1638,7 @@ mod tests {
 
     #[test]
     fn test_injection_from_vanilla() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-
+        let gazetteer = gazetteer!(("the rolling stones", "The Rolling Stones"),);
         let mut parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.6)
             .gazetteer(gazetteer)
@@ -1764,10 +1674,10 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "queens the stone age".to_string(),
+                matched_value: "queens the stone age".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "Queens Of The Stone Age".to_string(),
-                    matched_value: "queens of the stone age".to_string(),
+                    raw_value: "queens of the stone age".to_string(),
                 },
                 alternatives: vec![],
                 range: 16..36,
@@ -1792,16 +1702,10 @@ mod tests {
 
     #[test]
     fn test_injection_stop_words() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "The Rolling Stones".to_string(),
-            raw_value: "the rolling stones".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Stones".to_string(),
-            raw_value: "the stones".to_string(),
-        });
-
+        let gazetteer = gazetteer!(
+            ("the rolling stones", "The Rolling Stones"),
+            ("the stones", "The Stones"),
+        );
         let mut parser = ParserBuilder::default()
             .minimum_tokens_ratio(0.0)
             .gazetteer(gazetteer.clone())
@@ -1856,34 +1760,17 @@ mod tests {
 
     #[test]
     fn test_match_longest_substring() {
-        let mut gazetteer = Gazetteer::default();
-        gazetteer.add(EntityValue {
-            resolved_value: "Black And White".to_string(),
-            raw_value: "black and white".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "Album".to_string(),
-            raw_value: "album".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "The Black and White Album".to_string(),
-            raw_value: "the black and white album".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "1 2 3 4".to_string(),
-            raw_value: "one two three four".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "3 4 5 6".to_string(),
-            raw_value: "three four five six".to_string(),
-        });
-        gazetteer.add(EntityValue {
-            resolved_value: "6 7".to_string(),
-            raw_value: "six seven".to_string(),
-        });
+        let gazetteer = gazetteer!(
+            ("black and white", "Black And White"),
+            ("album", "Album"),
+            ("the black and white album", "The Black and White Album"),
+            ("one two three four", "1 2 3 4"),
+            ("three four five", "3 4 5"),
+            ("five six", "5 6"),
+        );
 
         let parser = ParserBuilder::default()
-            .minimum_tokens_ratio(0.5)
+            .minimum_tokens_ratio(0.7)
             .gazetteer(gazetteer)
             .build()
             .unwrap();
@@ -1894,268 +1781,85 @@ mod tests {
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "black and white album".to_string(),
+                matched_value: "black and white album".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "The Black and White Album".to_string(),
-                    matched_value: "the black and white album".to_string(),
+                    raw_value: "the black and white album".to_string(),
                 },
                 alternatives: vec![],
                 range: 19..40,
             }]
         );
 
-        let parsed = parser.run("one two three four").unwrap();
+        let parsed = parser.run("zero one two three four five").unwrap();
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "one two three four".to_string(),
+                matched_value: "one two three four".to_string(),
                 resolved_value: ResolvedValue {
                     resolved: "1 2 3 4".to_string(),
-                    matched_value: "one two three four".to_string(),
+                    raw_value: "one two three four".to_string(),
                 },
                 alternatives: vec![],
-                range: 0..18,
-            }]
+                range: 5..23,
+            },]
         );
 
-        // This test is ambiguous and there may be several acceptable answers...
         let parsed = parser.run("zero one two three four five six").unwrap();
         assert_eq!(
             parsed,
             vec![
                 ParsedValue {
-                    raw_value: "one two three four".to_string(),
+                    matched_value: "one two three four".to_string(),
                     resolved_value: ResolvedValue {
                         resolved: "1 2 3 4".to_string(),
-                        matched_value: "one two three four".to_string(),
+                        raw_value: "one two three four".to_string(),
                     },
                     alternatives: vec![],
                     range: 5..23,
                 },
                 ParsedValue {
-                    raw_value: "five six".to_string(),
+                    matched_value: "five six".to_string(),
                     resolved_value: ResolvedValue {
-                        resolved: "3 4 5 6".to_string(),
-                        matched_value: "three four five six".to_string(),
+                        resolved: "5 6".to_string(),
+                        raw_value: "five six".to_string(),
                     },
                     alternatives: vec![],
                     range: 24..32,
                 },
             ]
         );
-
-        let parsed = parser
-            .run("zero one two three four five six seven")
-            .unwrap();
-        assert_eq!(
-            parsed,
-            vec![
-                ParsedValue {
-                    raw_value: "one two three four".to_string(),
-                    resolved_value: ResolvedValue {
-                        resolved: "1 2 3 4".to_string(),
-                        matched_value: "one two three four".to_string(),
-                    },
-                    alternatives: vec![],
-                    range: 5..23,
-                },
-                ParsedValue {
-                    raw_value: "six seven".to_string(),
-                    resolved_value: ResolvedValue {
-                        resolved: "6 7".to_string(),
-                        matched_value: "six seven".to_string(),
-                    },
-                    alternatives: vec![],
-                    range: 29..38,
-                },
-            ]
-        );
     }
 
     #[test]
-    #[ignore]
-    fn real_world_gazetteer_parser() {
-        let (_, body) = CallBuilder::get().max_response(20000000).timeout_ms(60000).url("https://s3.amazonaws.com/snips/nlu-lm/test/gazetteer-entity-parser/artist_gazetteer_formatted.json").unwrap().exec().unwrap();
-        let data: Vec<EntityValue> = serde_json::from_reader(&*body).unwrap();
-        let gaz = Gazetteer { data };
+    fn test_alternative_matches() {
+        let gazetteer = gazetteer!(
+            ("space invader", "Space Invader"),
+            ("invader on mars", "Invader on Mars"),
+            ("invader attack", "Invader Attack"),
+        );
 
-        let n_stop_words = 50;
-        let mut parser = ParserBuilder::default()
-            .minimum_tokens_ratio(0.6)
-            .gazetteer(gaz)
-            .n_stop_words(n_stop_words)
+        let parser = ParserBuilder::default()
+            .minimum_tokens_ratio(0.5)
+            .gazetteer(gazetteer)
             .build()
             .unwrap();
 
-        let parsed = parser.run("je veux écouter les rolling stones").unwrap();
+        let parsed = parser.run("I want to play to invader").unwrap();
         assert_eq!(
             parsed,
             vec![ParsedValue {
-                raw_value: "rolling stones".to_string(),
+                matched_value: "invader".to_string(),
                 resolved_value: ResolvedValue {
-                    resolved: "The Rolling Stones".to_string(),
-                    matched_value: "the rolling stones".to_string(),
+                    resolved: "Space Invader".to_string(),
+                    raw_value: "space invader".to_string(),
                 },
-                alternatives: vec![],
-                range: 20..34,
+                alternatives: vec![ResolvedValue {
+                    resolved: "Invader Attack".to_string(),
+                    raw_value: "invader attack".to_string(),
+                }],
+                range: 18..25,
             }]
         );
-
-        parser.set_threshold(0.5);
-        let parsed = parser.run("je veux écouter bowie").unwrap();
-        assert_eq!(
-            parsed,
-            vec![ParsedValue {
-                raw_value: "bowie".to_string(),
-                resolved_value: ResolvedValue {
-                    resolved: "David Bowie".to_string(),
-                    matched_value: "david bowie".to_string(),
-                },
-                alternatives: vec![],
-                range: 16..21,
-            }]
-        );
-
-        let (_, body) = CallBuilder::get().max_response(20000000).timeout_ms(60000).url("https://s3.amazonaws.com/snips/nlu-lm/test/gazetteer-entity-parser/album_gazetteer_formatted.json").unwrap().exec().unwrap();
-        let data: Vec<EntityValue> = serde_json::from_reader(&*body).unwrap();
-        let gaz = Gazetteer { data };
-
-        let n_stop_words = 50;
-        let mut parser = ParserBuilder::default()
-            .minimum_tokens_ratio(0.6)
-            .gazetteer(gaz)
-            .n_stop_words(n_stop_words)
-            .build()
-            .unwrap();
-
-        let parsed = parser
-            .run("je veux écouter le black and white album")
-            .unwrap();
-        assert_eq!(
-            parsed,
-            vec![ParsedValue {
-                raw_value: "black and white album".to_string(),
-                resolved_value: ResolvedValue {
-                    resolved: "The Black and White Album".to_string(),
-                    matched_value: "black and white album".to_string(),
-                },
-                alternatives: vec![],
-                range: 19..40,
-            }]
-        );
-
-        let parsed = parser
-            .run("je veux écouter dark side of the moon")
-            .unwrap();
-        assert_eq!(
-            parsed,
-            vec![ParsedValue {
-                raw_value: "dark side of the moon".to_string(),
-                resolved_value: ResolvedValue {
-                    resolved: "Dark Side of the Moon".to_string(),
-                    matched_value: "dark side of the moon".to_string(),
-                },
-                alternatives: vec![],
-                range: 16..37,
-            }]
-        );
-
-        parser.set_threshold(0.5);
-        let parsed = parser
-            .run("je veux écouter dark side of the moon")
-            .unwrap();
-        assert_eq!(
-            parsed,
-            vec![
-                ParsedValue {
-                    raw_value: "je veux".to_string(),
-                    resolved_value: ResolvedValue {
-                        resolved: "Je veux du bonheur".to_string(),
-                        matched_value: "je veux du bonheur".to_string(),
-                    },
-                    alternatives: vec![],
-                    range: 0..7,
-                },
-                ParsedValue {
-                    raw_value: "dark side of the moon".to_string(),
-                    resolved_value: ResolvedValue {
-                        resolved: "Dark Side of the Moon".to_string(),
-                        matched_value: "dark side of the moon".to_string(),
-                    },
-                    alternatives: vec![],
-                    range: 16..37,
-                },
-            ]
-        );
-    }
-
-    #[test]
-    #[ignore]
-    fn test_real_word_injection() {
-        // Real-world artist gazetteer
-        let (_, body) = CallBuilder::get().max_response(20000000).timeout_ms(100000).url("https://s3.amazonaws.com/snips/nlu-lm/test/gazetteer-entity-parser/artist_gazetteer_formatted.json").unwrap().exec().unwrap();
-        let data: Vec<EntityValue> = serde_json::from_reader(&*body).unwrap();
-        let album_gaz = Gazetteer { data };
-
-        let mut parser_for_test = ParserBuilder::default()
-            .minimum_tokens_ratio(0.6)
-            .gazetteer(album_gaz.clone())
-            .n_stop_words(50)
-            .build()
-            .unwrap();
-
-        let mut parser = ParserBuilder::default()
-            .minimum_tokens_ratio(0.6)
-            .gazetteer(album_gaz)
-            .n_stop_words(50)
-            .build()
-            .unwrap();
-
-        // Get 10k values from the album gazetter to inject in the album parser
-        let (_, body) = CallBuilder::get().max_response(20000000).timeout_ms(100000).url("https://s3.amazonaws.com/snips/nlu-lm/test/gazetteer-entity-parser/album_gazetteer_formatted.json").unwrap().exec().unwrap();
-        let mut new_values: Vec<EntityValue> = serde_json::from_reader(&*body).unwrap();
-        new_values.truncate(10000);
-
-        // Test injection
-        parser_for_test.set_threshold(0.7);
-        let parsed = parser_for_test
-            .run("je veux écouter hans knappertsbusch conducts")
-            .unwrap();
-        assert_eq!(
-            parsed,
-            vec![ParsedValue {
-                raw_value: "hans knappertsbusch".to_string(),
-                resolved_value: ResolvedValue {
-                    resolved: "Hans Knappertsbusch".to_string(),
-                    matched_value: "hans knappertsbusch".to_string(),
-                },
-                alternatives: vec![],
-                range: 16..35,
-            }]
-        );
-        parser_for_test
-            .inject_new_values(new_values.clone(), true, false)
-            .unwrap();
-        parser_for_test.set_threshold(0.7);
-        let parsed = parser_for_test
-            .run("je veux écouter hans knappertsbusch conducts")
-            .unwrap();
-        assert_eq!(
-            parsed,
-            vec![ParsedValue {
-                raw_value: "hans knappertsbusch conducts".to_string(),
-                resolved_value: ResolvedValue {
-                    resolved: "Hans Knappertsbusch conducts".to_string(),
-                    matched_value: "hans knappertsbusch conducts".to_string(),
-                },
-                alternatives: vec![],
-                range: 16..44,
-            }]
-        );
-
-        let now = Instant::now();
-        parser.inject_new_values(new_values, true, false).unwrap();
-        let total_time = now.elapsed().as_secs();
-        assert!(total_time < 10);
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,10 +1,12 @@
-use constants::*;
-use data::EntityValue;
-use errors::*;
-use failure::ResultExt;
+use crate::constants::*;
+use crate::data::EntityValue;
+use crate::errors::*;
+use crate::symbol_table::{ResolvedSymbolTable, TokenSymbolTable};
+use crate::utils::{check_threshold, whitespace_tokenizer};
+use failure::{format_err, ResultExt};
 use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
-use rmps::{from_read, Serializer};
-use serde::Serialize;
+use rmp_serde::{from_read, Serializer};
+use serde::{Deserialize, Serialize};
 use serde_json;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
@@ -12,8 +14,6 @@ use std::collections::{BTreeSet, BinaryHeap};
 use std::fs;
 use std::ops::Range;
 use std::path::Path;
-use symbol_table::{ResolvedSymbolTable, TokenSymbolTable};
-use utils::{check_threshold, whitespace_tokenizer};
 
 /// Struct representing the parser. The Parser will match the longest possible contiguous
 /// substrings of a query that match partial entity values. The order in which the values are
@@ -867,15 +867,13 @@ fn group_matches(final_matches: Vec<PossibleMatch>) -> BinaryHeap<PossibleMatch>
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
-
-    use self::tempfile::tempdir;
     use super::*;
+    use crate::data::EntityValue;
+    use crate::data::Gazetteer;
     use crate::gazetteer;
-    use data::EntityValue;
-    use data::Gazetteer;
+    use crate::parser_builder::ParserBuilder;
     use failure::ResultExt;
-    use parser_builder::ParserBuilder;
+    use tempfile::tempdir;
 
     fn get_license_info() -> LicenseInfo {
         let license_content = "Some content here".to_string();

--- a/src/parser_builder.rs
+++ b/src/parser_builder.rs
@@ -1,7 +1,9 @@
-use data::Gazetteer;
-use errors::*;
-use parser::{LicenseInfo, Parser};
-use EntityValue;
+use crate::data::Gazetteer;
+use crate::errors::*;
+use crate::parser::{LicenseInfo, Parser};
+use crate::EntityValue;
+use failure::format_err;
+use serde::{Deserialize, Serialize};
 
 /// Struct exposing a builder allowing to configure and build a Parser
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
@@ -105,7 +107,7 @@ impl ParserBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use data::EntityValue;
+    use crate::data::EntityValue;
     use serde_json;
 
     fn get_license_info() -> LicenseInfo {

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -1,9 +1,9 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
 /// Implementation of a symbol table that
 /// - always maps a given index to a single string
 /// - allows mapping a string to several indices
-
-use std::collections::BTreeMap;
-
 #[derive(PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
 pub struct TokenSymbolTable {
     string_to_index: BTreeMap<String, u32>,
@@ -41,10 +41,7 @@ impl TokenSymbolTable {
     /// Remove the unique symbol corresponding to an index in the symbol table
     pub fn remove_index(&mut self, idx: &u32) -> Option<String> {
         let symbol = self.find_index(idx).cloned();
-        symbol.and_then(|symbol|
-            self.string_to_index
-                .remove(&symbol)
-                .map(|_| symbol))
+        symbol.and_then(|symbol| self.string_to_index.remove(&symbol).map(|_| symbol))
     }
 }
 
@@ -82,11 +79,9 @@ impl ResolvedSymbolTable {
     /// Remove a symbol and all its linked indices from the symbol table
     pub fn remove_symbol(&mut self, symbol: &str) -> Vec<u32> {
         let indices = self.find_symbol(symbol);
-        indices.into_iter()
-            .flat_map(|idx|
-                self.index_to_resolved
-                    .remove(&idx)
-                    .map(|_| idx))
+        indices
+            .into_iter()
+            .flat_map(|idx| self.index_to_resolved.remove(&idx).map(|_| idx))
             .collect()
     }
 


### PR DESCRIPTION
### Description
This PR adds the ability to retrieve alternative resolved values for a single match, through a new `max_alternatives` parameter on the `Parser::run` API. 
Let's say you have a gazetteer parser with the following (raw_value, resolved) pairs:
- `("space invader", "Space Invader Limited Edition")`
- `("invader attack", "Invader Attack 3")`

Parsing the input `"I want to play to the invader game"` with a minimum tokens ratio of 0.5 would previously yield:

```rust
vec![ParsedValue {
    raw_value: "invader".to_string(),
    resolved_value: "Space Invader Limited Edition".to_string(),
    matched_value: "space invader".to_string(),
    range: 22..29,
}]
```

In this case, as both gazetteer entries have matched the same number of tokens, the entry with the highest rank is selected. Information about the other entry is lost, even though it could be used by the client code:

After the suggested changes, the output will rather be:
 ```rust
vec![ParsedValue {
    matched_value: "invader".to_string(),
    resolved_value: ResolvedValue {
        resolved: "Space Invader Limited Edition".to_string(),
        raw_value: "space invader".to_string(),
    },
    alternatives: vec![ResolvedValue {
        resolved: "Invader Attack 3".to_string(),
        raw_value: "invader attack".to_string(),
    }],
    range: 22..29,
}]
```

The performances in terms of speed are not affected significantly by this change.

### Other changes
The `matched_value` and `raw_value` attributes have been switched for consistency:
- `matched_value`: the string in the input which was matched
- `raw_value`: the value in the gazetteer which was matched by the `matched_value`