### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,18 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.8.0] - 2019-08-27
 ### Changed
 - Add `max_alternatives` parameter to the `Parser::run` API [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
 - Add `alternatives` attribute in `ParsedValue` [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
 - Switch `matched_value` and `raw_value` [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
 - Group `resolved_value` and `matched_value` in a dedicated `ResolvedValue` object [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
 
-## [0.7.2]
+## [0.7.2] - 2019-07-19
 ### Fixed
 - Make `LicenseInfo` public [#38](https://github.com/snipsco/gazetteer-entity-parser/pull/38)
 
-## [0.7.1]
+## [0.7.1] - 2019-07-18
 ### Added
 - Add a license file to the gazetteer entity parser [#36](https://github.com/snipsco/gazetteer-entity-parser/pull/36)
 
@@ -34,7 +34,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Clearer `ParserBuilder`'s API 
 
-[Unreleased]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.7.2...HEAD
+[0.8.0]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.7.2...0.8.0
 [0.7.2]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/snipsco/gazetteer-entity-parser/compare/0.6.0...0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gazetteer-entity-parser"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Alaa Saade <alaa.saade@snips.ai>"]
 repository = "https://github.com/snipsco/gazetteer-entity-parser"
 description = "Gazetteer-based entity parser"

--- a/README.rst
+++ b/README.rst
@@ -12,41 +12,53 @@ Example
 
 .. code-block:: rust
 
-    extern crate gazetteer_entity_parser;
-
-    use gazetteer_entity_parser::*;
-
-    fn main() {
-        let gazetteer = gazetteer!(
-            ("king of pop", "Michael Jackson"),
-            ("the rolling stones", "The Rolling Stones"),
-            ("the beatles", "The Beatles"),
-            ("queen of soul", "Aretha Franklin"),
-            ("the red hot chili peppers", "The Red Hot Chili Peppers"),
-        );
-        let parser = ParserBuilder::default()
-            .gazetteer(gazetteer)
-            .minimum_tokens_ratio(2. / 3.)
-            .build()
-            .unwrap();
-
-        let sentence = "My favourite artists are the stones and the amazing fab four";
-        let extracted_entities = parser.run(sentence).unwrap();
-        assert_eq!(extracted_entities,
-                   vec![
-                       ParsedValue {
-                           raw_value: "the stones".to_string(),
-                           matched_value: "the rolling stones".to_string(),
-                           resolved_value: "The Rolling Stones".to_string(),
-                           range: 25..35,
-                       },
-                       ParsedValue {
-                           raw_value: "fab four".to_string(),
-                           matched_value: "the fab four".to_string(),
-                           resolved_value: "The Beatles".to_string(),
-                           range: 52..60,
-                       }]);
-    }
+   extern crate gazetteer_entity_parser;
+   
+   use gazetteer_entity_parser::*;
+   
+   fn main() {
+       let gazetteer = gazetteer!(
+           ("king of pop", "Michael Jackson"),
+           ("the rolling stones", "The Rolling Stones"),
+           ("the crying stones", "The Crying Stones"),
+           ("the fab four", "The Beatles"),
+           ("queen of soul", "Aretha Franklin"),
+       );
+       let parser = ParserBuilder::default()
+           .gazetteer(gazetteer)
+           .minimum_tokens_ratio(2. / 3.)
+           .build()
+           .unwrap();
+   
+       let sentence = "My favourite artists are the stones and fab four";
+       let extracted_entities = parser.run(sentence, 5).unwrap();
+       assert_eq!(
+           extracted_entities,
+           vec![
+               ParsedValue {
+                   matched_value: "the stones".to_string(),
+                   resolved_value: ResolvedValue {
+                       resolved: "The Rolling Stones".to_string(),
+                       raw_value: "the rolling stones".to_string(),
+                   },
+                   alternatives: vec![ResolvedValue {
+                       resolved: "The Crying Stones".to_string(),
+                       raw_value: "the crying stones".to_string(),
+                   }],
+                   range: 25..35,
+               },
+               ParsedValue {
+                   matched_value: "fab four".to_string(),
+                   resolved_value: ResolvedValue {
+                       resolved: "The Beatles".to_string(),
+                       raw_value: "the fab four".to_string(),
+                   },
+                   alternatives: vec![],
+                   range: 40..48,
+               }
+           ]
+       );
+   }
 
 
 License

--- a/examples/entity_parsing_from_scratch.rs
+++ b/examples/entity_parsing_from_scratch.rs
@@ -6,9 +6,9 @@ fn main() {
     let gazetteer = gazetteer!(
         ("king of pop", "Michael Jackson"),
         ("the rolling stones", "The Rolling Stones"),
+        ("the crying stones", "The Crying Stones"),
         ("the fab four", "The Beatles"),
         ("queen of soul", "Aretha Franklin"),
-        ("the red hot chili peppers", "The Red Hot Chili Peppers"),
     );
     let parser = ParserBuilder::default()
         .gazetteer(gazetteer)
@@ -27,7 +27,10 @@ fn main() {
                     resolved: "The Rolling Stones".to_string(),
                     raw_value: "the rolling stones".to_string(),
                 },
-                alternatives: vec![],
+                alternatives: vec![ResolvedValue {
+                    resolved: "The Crying Stones".to_string(),
+                    raw_value: "the crying stones".to_string(),
+                }],
                 range: 25..35,
             },
             ParsedValue {


### PR DESCRIPTION
### Changed
- Add `max_alternatives` parameter to the `Parser::run` API [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
- Add `alternatives` attribute in `ParsedValue` [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
- Switch `matched_value` and `raw_value` [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)
- Group `resolved_value` and `matched_value` in a dedicated `ResolvedValue` object [#39](https://github.com/snipsco/gazetteer-entity-parser/pull/39)