### PR TITLE
Prevent from injecting empty values

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,6 +12,7 @@ use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, BinaryHeap};
 use std::fs;
+use std::iter;
 use std::ops::Range;
 use std::path::Path;
 
@@ -159,37 +160,35 @@ impl Parser {
     /// Add a single entity value, along with its rank, to the parser
     /// The ranks of the other entity values will not be changed
     pub fn add_value(&mut self, entity_value: EntityValue, rank: u32) -> Result<()> {
-        // We force add the new resolved value: even if it is already present in the symbol table
-        // we duplicate it to allow several raw values to map to it
-        let res_value_idx = self
-            .resolved_symbol_table
-            .add_symbol(entity_value.resolved_value);
+        let mut tokens = whitespace_tokenizer(&entity_value.raw_value);
+        if let Some(first_token) = tokens.next() {
+            let tokens_it = iter::once(first_token).chain(tokens);
+            // We force add the new resolved value: even if it is already present in the symbol table
+            // we duplicate it to allow several raw values to map to it
+            let res_value_idx = self
+                .resolved_symbol_table
+                .add_symbol(entity_value.resolved_value);
+            for (_, token) in tokens_it {
+                let token_idx = self.tokens_symbol_table.add_symbol(token);
 
-        let tokens: Vec<(Range<usize>, String)> = whitespace_tokenizer(&entity_value.raw_value)
-            .into_iter()
-            .collect();
+                // Update token_to_resolved_values map
+                self.token_to_resolved_values
+                    .entry(token_idx)
+                    .and_modify(|e| {
+                        e.insert(res_value_idx);
+                    })
+                    .or_insert_with(|| vec![res_value_idx].into_iter().collect());
 
-        if tokens.len() == 0 {
+                // Update resolved_value_to_tokens map
+                self.resolved_value_to_tokens
+                    .entry(res_value_idx)
+                    .and_modify(|(_, v)| v.push(token_idx))
+                    .or_insert((rank, vec![token_idx]));
+            }
+        } else {
             bail!("Can't add value '{}' because it's empty or contains only whitespaces.", entity_value.raw_value)
         }
 
-        for (_, token) in tokens.into_iter() {
-            let token_idx = self.tokens_symbol_table.add_symbol(token);
-
-            // Update token_to_resolved_values map
-            self.token_to_resolved_values
-                .entry(token_idx)
-                .and_modify(|e| {
-                    e.insert(res_value_idx);
-                })
-                .or_insert_with(|| vec![res_value_idx].into_iter().collect());
-
-            // Update resolved_value_to_tokens map
-            self.resolved_value_to_tokens
-                .entry(res_value_idx)
-                .and_modify(|(_, v)| v.push(token_idx))
-                .or_insert((rank, vec![token_idx]));
-        }
         Ok(())
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@ use crate::data::EntityValue;
 use crate::errors::*;
 use crate::symbol_table::{ResolvedSymbolTable, TokenSymbolTable};
 use crate::utils::{check_threshold, whitespace_tokenizer};
-use failure::{format_err, ResultExt};
+use failure::{bail, format_err, ResultExt};
 use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use rmp_serde::{from_read, Serializer};
 use serde::{Deserialize, Serialize};
@@ -158,14 +158,22 @@ impl PartialOrd for ParsedValue {
 impl Parser {
     /// Add a single entity value, along with its rank, to the parser
     /// The ranks of the other entity values will not be changed
-    pub fn add_value(&mut self, entity_value: EntityValue, rank: u32) {
+    pub fn add_value(&mut self, entity_value: EntityValue, rank: u32) -> Result<()> {
         // We force add the new resolved value: even if it is already present in the symbol table
         // we duplicate it to allow several raw values to map to it
         let res_value_idx = self
             .resolved_symbol_table
             .add_symbol(entity_value.resolved_value);
 
-        for (_, token) in whitespace_tokenizer(&entity_value.raw_value) {
+        let tokens: Vec<(Range<usize>, String)> = whitespace_tokenizer(&entity_value.raw_value)
+            .into_iter()
+            .collect();
+
+        if tokens.len() == 0 {
+            bail!("Can't add value '{}' because it's empty or contains only whitespaces.", entity_value.raw_value)
+        }
+
+        for (_, token) in tokens.into_iter() {
             let token_idx = self.tokens_symbol_table.add_symbol(token);
 
             // Update token_to_resolved_values map
@@ -182,10 +190,11 @@ impl Parser {
                 .and_modify(|(_, v)| v.push(token_idx))
                 .or_insert((rank, vec![token_idx]));
         }
+        Ok(())
     }
 
     /// Prepend a list of entity values to the parser and update the ranks accordingly
-    pub fn prepend_values(&mut self, entity_values: Vec<EntityValue>) {
+    pub fn prepend_values(&mut self, entity_values: Vec<EntityValue>) -> Result<()> {
         // update rank of previous values
         for res_val in self.resolved_symbol_table.get_all_indices() {
             self.resolved_value_to_tokens
@@ -193,13 +202,14 @@ impl Parser {
                 .and_modify(|(rank, _)| *rank += entity_values.len() as u32);
         }
         for (rank, entity_value) in entity_values.into_iter().enumerate() {
-            self.add_value(entity_value.clone(), rank as u32);
+            self.add_value(entity_value.clone(), rank as u32)?;
         }
 
         // Update the stop words and edge cases
         let n_stop_words = self.n_stop_words;
         let additional_stop_words = self.additional_stop_words.clone();
         self.set_stop_words(n_stop_words, Some(additional_stop_words));
+        Ok(())
     }
 
     /// Set the threshold (minimum fraction of tokens to match for an entity to be parsed).
@@ -362,7 +372,7 @@ impl Parser {
         };
 
         for (rank, entity_value) in new_values.into_iter().enumerate() {
-            self.add_value(entity_value.clone(), new_start_rank + rank as u32);
+            self.add_value(entity_value.clone(), new_start_rank + rank as u32)?;
             self.injected_values.insert(entity_value.resolved_value);
         }
 
@@ -1347,7 +1357,7 @@ mod tests {
             },
         ];
 
-        parser.prepend_values(values_to_prepend);
+        parser.prepend_values(values_to_prepend).unwrap();
 
         let parsed = parser.run(input, 5).unwrap();
         assert_eq!(
@@ -1716,6 +1726,26 @@ mod tests {
         assert!(!parser
             .resolved_value_to_tokens
             .contains_key(&flying_stones_idx));
+    }
+
+    #[test]
+    fn test_injection_should_fail_when_adding_empty_values() {
+        let gazetteer = Gazetteer::default();
+        let mut parser = ParserBuilder::default()
+            .minimum_tokens_ratio(0.6)
+            .gazetteer(gazetteer)
+            .build()
+            .unwrap();
+
+        let new_values_1 = vec![EntityValue {
+            resolved_value: "some_resolved_value".to_string(),
+            raw_value: " ".to_string(),
+        }];
+
+        let is_err = parser
+            .inject_new_values(new_values_1.clone(), true, true)
+            .is_err();
+        assert!(is_err);
     }
 
     #[test]

--- a/src/parser_builder.rs
+++ b/src/parser_builder.rs
@@ -86,13 +86,10 @@ impl ParserBuilder {
                 self.threshold
             ));
         }
-        let mut parser = self.gazetteer.data.into_iter().enumerate().fold(
-            Parser::default(),
-            |mut parser, (rank, entity_value)| {
-                parser.add_value(entity_value, rank as u32);
-                parser
-            },
-        );
+        let mut parser = Parser::default();
+        for (rank, entity_value) in self.gazetteer.data.into_iter().enumerate() {
+            parser.add_value(entity_value, rank as u32)?;
+        }
         parser.set_threshold(self.threshold);
         parser.set_stop_words(
             self.n_gazetteer_stop_words.unwrap_or(0),
@@ -151,7 +148,7 @@ mod tests {
         // Then
         let mut expected_parser = Parser::default();
         for (rank, entity_value) in gazetteer.data.into_iter().enumerate() {
-            expected_parser.add_value(entity_value, rank as u32);
+            expected_parser.add_value(entity_value, rank as u32).unwrap();
         }
         expected_parser.set_threshold(0.5);
         expected_parser.set_stop_words(2, Some(vec!["hello".to_string()]));
@@ -196,10 +193,10 @@ mod tests {
         // Then
         let mut expected_parser = Parser::default();
         for (rank, entity_value) in entity_values_1.into_iter().enumerate() {
-            expected_parser.add_value(entity_value, rank as u32);
+            expected_parser.add_value(entity_value, rank as u32).unwrap();
         }
         for (rank, entity_value) in entity_values_2.into_iter().enumerate() {
-            expected_parser.add_value(entity_value, 1 + rank as u32);
+            expected_parser.add_value(entity_value, 1 + rank as u32).unwrap();
         }
         expected_parser.set_threshold(0.5);
         expected_parser.set_stop_words(2, Some(vec!["hello".to_string()]));
@@ -238,7 +235,7 @@ mod tests {
         // Then
         let mut expected_parser = Parser::default();
         for (rank, entity_value) in entity_values.into_iter().enumerate() {
-            expected_parser.add_value(entity_value, rank as u32);
+            expected_parser.add_value(entity_value, rank as u32).unwrap();
         }
         expected_parser.set_threshold(0.5);
         expected_parser.set_stop_words(2, Some(vec!["hello".to_string()]));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,7 @@ pub struct WhitespaceTokenizer<'a> {
     char_iterator: Peekable<Chars<'a>>,
 }
 
-/// Creates a tokenizer that splits on whitespace and is robust to mutilple and types of whitespaces
+/// Creates a tokenizer that splits on whitespace and is robust to multiple and types of whitespaces
 pub fn whitespace_tokenizer(string: &str) -> WhitespaceTokenizer {
     WhitespaceTokenizer {
         char_iterator: string.chars().peekable(),
@@ -62,7 +62,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn whitespace_tokenizer_works_with_mutiple_spaces() {
+    fn whitespace_tokenizer_works_with_multiple_spaces() {
         let mut tokenizer = whitespace_tokenizer("ceci est un   \t test ");
         assert_eq!(tokenizer.next(), Some((0..4, "ceci".to_string())));
         assert_eq!(tokenizer.next(), Some((5..8, "est".to_string())));


### PR DESCRIPTION
Prevent the user to inject empty values.  By empty we mean values that contain no characters or only whitespaces.

This was previously allowed and made the injection from vanilla crash when trying to inject after injecting an empty character:
- when adding the value the first time, the tokenizer used to remove whitespaces from the value couldn't find any token, hence the `tokens_symbol_table`, `token_to_resolved_values` and `resolved_value_to_tokens` where not updated with any token.
- when injecting a second time, we try to remove the resolved value from the `resolved_symbol_table` but then when trying to get the tokens of the resolved value with `get_tokens_from_resolved_value` in order to remove them from the `tokens_symbol_table`, `token_to_resolved_values` and `resolved_value_to_tokens` maps, we can't find any token for the given resolved value since we didn't insert any